### PR TITLE
Solved #9

### DIFF
--- a/lib/arboreal.js
+++ b/lib/arboreal.js
@@ -236,8 +236,10 @@
     return nodeList;
   };
 
-  Arboreal.prototype.__defineGetter__("length", function () {
-    return this.toArray().length;
+  Object.defineProperty(Arboreal.prototype, 'length', {
+    get: function() {
+      return this.toArray().length;
+    };
   });
 
 


### PR DESCRIPTION
Replaced the deprecated **defineGetter**() with the standard
Object.defineProperty(). Should now work with IE 9+ instead of 11+.
